### PR TITLE
Fix compatibility with ESPHome 2025.7.0 and deprecation of TEXT_SENSOR_SCHEMA

### DIFF
--- a/components/obis_d0/__init__.py
+++ b/components/obis_d0/__init__.py
@@ -2,7 +2,7 @@ import re
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.cpp_helpers import setup_entity
+# from esphome.cpp_helpers import setup_entity
 from esphome.components import uart
 from esphome.const import CONF_ID, CONF_TRIGGER_ID
 from esphome import automation

--- a/components/obis_d0/text_sensor/__init__.py
+++ b/components/obis_d0/text_sensor/__init__.py
@@ -10,7 +10,7 @@ AUTO_LOAD = ["obis_d0"]
 SmartMeterD0TextSensor = obis_d0_ns.class_(
     "SmartMeterD0TextSensor", text_sensor.TextSensor, cg.Component)
 
-CONFIG_SCHEMA = text_sensor.TEXT_SENSOR_SCHEMA.extend(
+CONFIG_SCHEMA = text_sensor.text_sensor_schema().extend(
     {
         cv.GenerateID(): cv.declare_id(SmartMeterD0TextSensor),
         cv.GenerateID(CONF_OBIS_D0_ID): cv.use_id(SmartMeterD0),


### PR DESCRIPTION
- Removed unused import of setup_entity (removed from ESPHome 2025.7.0)
- Replaced deprecated TEXT_SENSOR_SCHEMA with text_sensor_schema() per ESPHome 2025.11.0 deprecation notice:
  https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/

Tested with ESPHome 2025.7.0.
